### PR TITLE
set platform to 9.0 so that it will still install on older versions

### DIFF
--- a/RNStaticSafeAreaInsets.podspec
+++ b/RNStaticSafeAreaInsets.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage     = package["repository"]["baseUrl"]
   s.license      = package["license"]
   s.author       = { "author" => package["author"]["email"] }
-  s.platform     = :ios, "11.0"
+  s.platform     = :ios, "9.0"
   s.source       = { :git => "#{package["repository"]["baseUrl"]}.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m}"

--- a/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
+++ b/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
@@ -29,7 +29,7 @@ public class RNStaticSafeAreaInsetsModule extends ReactContextBaseJavaModule {
   public Map<String, Object> getConstants() {
     final Map<String, Object> constants = new HashMap<>();
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       final Activity activity = getCurrentActivity();
       final View view = activity.getWindow().getDecorView();
       final WindowInsets insets = view.getRootWindowInsets();


### PR DESCRIPTION
Hey, thanks for the work on this repo!

The `pod install` fails if the app's target platform is less than 11.0. Changed it so that it supports back to version 9.0. Also, `getRootWindowInsets` was added in API level 23!