### PR TITLE
[Android] Handle case when getCurrentActivity() returns null

### DIFF
--- a/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
+++ b/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
@@ -29,7 +29,7 @@ public class RNStaticSafeAreaInsetsModule extends ReactContextBaseJavaModule {
   public Map<String, Object> getConstants() {
     final Map<String, Object> constants = new HashMap<>();
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+    if (getCurrentActivity() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       final Activity activity = getCurrentActivity();
       final View view = activity.getWindow().getDecorView();
       final WindowInsets insets = view.getRootWindowInsets();


### PR DESCRIPTION
Fix for the issue: https://github.com/Gaspard-Bruno/react-native-static-safe-area-insets/issues/5