### PR TITLE
Add method `getSafeAreaInsets(callback)`

### DIFF
--- a/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
+++ b/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
@@ -1,6 +1,5 @@
 package com.gaspardbruno.staticsafeareainsets;
 
-import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -51,25 +50,38 @@ public class RNStaticSafeAreaInsetsModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void getSafeAreaInsets(Callback cb) {
-    final Map<String, Object> constants = new HashMap<>();
-
+  public float getSafeAreaInsetsTop() {
     if (getCurrentActivity() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      final Activity activity = getCurrentActivity();
-      final View view = activity.getWindow().getDecorView();
-      final WindowInsets insets = view.getRootWindowInsets();
-
-      constants.put("top", insets.getSystemWindowInsetTop());
-      constants.put("bottom", insets.getSystemWindowInsetBottom());
-      constants.put("left", insets.getSystemWindowInsetLeft());
-      constants.put("right", insets.getSystemWindowInsetRight());
+      return insets.getSystemWindowInsetTop();
     } else {
-      constants.put("top", 0);
-      constants.put("bottom", 0);
-      constants.put("left", 0);
-      constants.put("right", 0);
+      return 0;
     }
+  }
 
-    cb.invoke(constants);
+  @ReactMethod
+  public float getSafeAreaInsetsBottom() {
+    if (getCurrentActivity() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      return insets.getSystemWindowInsetBottom();
+    } else {
+      return 0;
+    }
+  }
+
+  @ReactMethod
+  public float getSafeAreaInsetsLeft() {
+    if (getCurrentActivity() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      return insets.getSystemWindowInsetLeft();
+    } else {
+      return 0;
+    }
+  }
+
+  @ReactMethod
+  public float getSafeAreaInsetsRight() {
+    if (getCurrentActivity() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      return insets.getSystemWindowInsetRight();
+    } else {
+      return 0;
+    }
   }
 }

--- a/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
+++ b/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
@@ -4,6 +4,7 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableNativeMap;
 
 import java.util.Map;
 import java.util.HashMap;

--- a/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
+++ b/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
@@ -1,5 +1,6 @@
 package com.gaspardbruno.staticsafeareainsets;
 
+import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -30,27 +31,15 @@ public class RNStaticSafeAreaInsetsModule extends ReactContextBaseJavaModule {
   public Map<String, Object> getConstants() {
     final Map<String, Object> constants = new HashMap<>();
 
-    if (getCurrentActivity() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      final Activity activity = getCurrentActivity();
-      final View view = activity.getWindow().getDecorView();
-      final WindowInsets insets = view.getRootWindowInsets();
-
-      constants.put("safeAreaInsetsTop", insets.getSystemWindowInsetTop());
-      constants.put("safeAreaInsetsBottom", insets.getSystemWindowInsetBottom());
-      constants.put("safeAreaInsetsLeft", insets.getSystemWindowInsetLeft());
-      constants.put("safeAreaInsetsRight", insets.getSystemWindowInsetRight());
-    } else {
-      constants.put("safeAreaInsetsTop", 0);
-      constants.put("safeAreaInsetsBottom", 0);
-      constants.put("safeAreaInsetsLeft", 0);
-      constants.put("safeAreaInsetsRight", 0);
-    }
+    constants.put("safeAreaInsetsTop", this._getSafeAreaInsetsTop());
+    constants.put("safeAreaInsetsBottom", this._getSafeAreaInsetsBottom());
+    constants.put("safeAreaInsetsLeft", this._getSafeAreaInsetsLeft());
+    constants.put("safeAreaInsetsRight", this._getSafeAreaInsetsRight());
 
     return constants;
   }
 
-  @ReactMethod
-  public float getSafeAreaInsetsTop() {
+  private float _getSafeAreaInsetsTop() {
     if (getCurrentActivity() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       return insets.getSystemWindowInsetTop();
     } else {
@@ -58,8 +47,7 @@ public class RNStaticSafeAreaInsetsModule extends ReactContextBaseJavaModule {
     }
   }
 
-  @ReactMethod
-  public float getSafeAreaInsetsBottom() {
+  private float _getSafeAreaInsetsBottom() {
     if (getCurrentActivity() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       return insets.getSystemWindowInsetBottom();
     } else {
@@ -67,8 +55,7 @@ public class RNStaticSafeAreaInsetsModule extends ReactContextBaseJavaModule {
     }
   }
 
-  @ReactMethod
-  public float getSafeAreaInsetsLeft() {
+  private float _getSafeAreaInsetsLeft() {
     if (getCurrentActivity() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       return insets.getSystemWindowInsetLeft();
     } else {
@@ -76,12 +63,31 @@ public class RNStaticSafeAreaInsetsModule extends ReactContextBaseJavaModule {
     }
   }
 
-  @ReactMethod
-  public float getSafeAreaInsetsRight() {
+  private float _getSafeAreaInsetsRight() {
     if (getCurrentActivity() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       return insets.getSystemWindowInsetRight();
     } else {
       return 0;
     }
+  }
+
+  @ReactMethod
+  public float getSafeAreaInsetsTop(Callback cb) {
+    cb.invoke(this._getSafeAreaInsetsTop());
+  }
+
+  @ReactMethod
+  public float getSafeAreaInsetsBottom(Callback cb) {
+    cb.invoke(this._getSafeAreaInsetsBottom());
+  }
+
+  @ReactMethod
+  public float getSafeAreaInsetsLeft(Callback cb) {
+    cb.invoke(this._getSafeAreaInsetsLeft());
+  }
+
+  @ReactMethod
+  public float getSafeAreaInsetsRight(Callback cb) {
+    cb.invoke(this._getSafeAreaInsetsRight());
   }
 }

--- a/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
+++ b/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
@@ -55,7 +55,7 @@ public class RNStaticSafeAreaInsetsModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public Map<String, Object> getSafeAreaInsets(Callback cb) {
+  public void getSafeAreaInsets(Callback cb) {
     cb.invoke(this._getSafeAreaInsets());
   }
 }

--- a/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
+++ b/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
@@ -1,7 +1,9 @@
 package com.gaspardbruno.staticsafeareainsets;
 
+import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -46,5 +48,28 @@ public class RNStaticSafeAreaInsetsModule extends ReactContextBaseJavaModule {
     }
 
     return constants;
+  }
+
+  @ReactMethod
+  public void getSafeAreaInsets(Callback cb) {
+    final Map<String, Object> constants = new HashMap<>();
+
+    if (getCurrentActivity() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      final Activity activity = getCurrentActivity();
+      final View view = activity.getWindow().getDecorView();
+      final WindowInsets insets = view.getRootWindowInsets();
+
+      constants.put("top", insets.getSystemWindowInsetTop());
+      constants.put("bottom", insets.getSystemWindowInsetBottom());
+      constants.put("left", insets.getSystemWindowInsetLeft());
+      constants.put("right", insets.getSystemWindowInsetRight());
+    } else {
+      constants.put("top", 0);
+      constants.put("bottom", 0);
+      constants.put("left", 0);
+      constants.put("right", 0);
+    }
+
+    cb.invoke(constants);
   }
 }

--- a/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
+++ b/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
@@ -5,6 +5,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.bridge.WritableMap;
 
 import java.util.Map;
 import java.util.HashMap;

--- a/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
+++ b/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
@@ -56,6 +56,14 @@ public class RNStaticSafeAreaInsetsModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void getSafeAreaInsets(Callback cb) {
-    cb.invoke(this._getSafeAreaInsets());
+    Map<String, Object> constants = this._getSafeAreaInsets();
+    WritableMap map = new WritableNativeMap();
+
+    map.putInt("safeAreaInsetsTop", (Integer) constants.safeAreaInsetsTop);
+    map.putInt("safeAreaInsetsBottom", (Integer) constants.safeAreaInsetsBottom);
+    map.putInt("safeAreaInsetsLeft", (Integer) constants.safeAreaInsetsLeft);
+    map.putInt("safeAreaInsetsRight", (Integer) constants.safeAreaInsetsRight);
+
+    cb.invoke(map);
   }
 }

--- a/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
+++ b/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
@@ -29,65 +29,33 @@ public class RNStaticSafeAreaInsetsModule extends ReactContextBaseJavaModule {
 
   @Override
   public Map<String, Object> getConstants() {
+    return this._getSafeAreaInsets();
+  }
+
+  private Map<String, Object> _getSafeAreaInsets() {
     final Map<String, Object> constants = new HashMap<>();
 
-    constants.put("safeAreaInsetsTop", this._getSafeAreaInsetsTop());
-    constants.put("safeAreaInsetsBottom", this._getSafeAreaInsetsBottom());
-    constants.put("safeAreaInsetsLeft", this._getSafeAreaInsetsLeft());
-    constants.put("safeAreaInsetsRight", this._getSafeAreaInsetsRight());
+    if (getCurrentActivity() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      final Activity activity = getCurrentActivity();
+      final View view = activity.getWindow().getDecorView();
+      final WindowInsets insets = view.getRootWindowInsets();
+
+      constants.put("safeAreaInsetsTop", insets.getSystemWindowInsetTop());
+      constants.put("safeAreaInsetsBottom", insets.getSystemWindowInsetBottom());
+      constants.put("safeAreaInsetsLeft", insets.getSystemWindowInsetLeft());
+      constants.put("safeAreaInsetsRight", insets.getSystemWindowInsetRight());
+    } else {
+      constants.put("safeAreaInsetsTop", 0);
+      constants.put("safeAreaInsetsBottom", 0);
+      constants.put("safeAreaInsetsLeft", 0);
+      constants.put("safeAreaInsetsRight", 0);
+    }
 
     return constants;
   }
 
-  private float _getSafeAreaInsetsTop() {
-    if (getCurrentActivity() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      return insets.getSystemWindowInsetTop();
-    } else {
-      return 0;
-    }
-  }
-
-  private float _getSafeAreaInsetsBottom() {
-    if (getCurrentActivity() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      return insets.getSystemWindowInsetBottom();
-    } else {
-      return 0;
-    }
-  }
-
-  private float _getSafeAreaInsetsLeft() {
-    if (getCurrentActivity() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      return insets.getSystemWindowInsetLeft();
-    } else {
-      return 0;
-    }
-  }
-
-  private float _getSafeAreaInsetsRight() {
-    if (getCurrentActivity() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      return insets.getSystemWindowInsetRight();
-    } else {
-      return 0;
-    }
-  }
-
   @ReactMethod
-  public float getSafeAreaInsetsTop(Callback cb) {
-    cb.invoke(this._getSafeAreaInsetsTop());
-  }
-
-  @ReactMethod
-  public float getSafeAreaInsetsBottom(Callback cb) {
-    cb.invoke(this._getSafeAreaInsetsBottom());
-  }
-
-  @ReactMethod
-  public float getSafeAreaInsetsLeft(Callback cb) {
-    cb.invoke(this._getSafeAreaInsetsLeft());
-  }
-
-  @ReactMethod
-  public float getSafeAreaInsetsRight(Callback cb) {
-    cb.invoke(this._getSafeAreaInsetsRight());
+  public Map<String, Object> getSafeAreaInsets(Callback cb) {
+    cb.invoke(this._getSafeAreaInsets());
   }
 }

--- a/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
+++ b/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
@@ -58,13 +58,35 @@ public class RNStaticSafeAreaInsetsModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void getSafeAreaInsets(Callback cb) {
-    Map<String, Object> constants = this._getSafeAreaInsets();
+    // Approach A
+    // Map<String, Object> constants = this._getSafeAreaInsets();
+    // WritableMap map = new WritableNativeMap();
+
+    // map.putInt("safeAreaInsetsTop", constants.safeAreaInsetsTop);
+    // map.putInt("safeAreaInsetsBottom", constants.safeAreaInsetsBottom);
+    // map.putInt("safeAreaInsetsLeft", constants.safeAreaInsetsLeft);
+    // map.putInt("safeAreaInsetsRight", constants.safeAreaInsetsRight);
+
+    // cb.invoke(map);
+
+    // Approach B
     WritableMap map = new WritableNativeMap();
 
-    map.putInt("safeAreaInsetsTop", (Integer) constants.safeAreaInsetsTop);
-    map.putInt("safeAreaInsetsBottom", (Integer) constants.safeAreaInsetsBottom);
-    map.putInt("safeAreaInsetsLeft", (Integer) constants.safeAreaInsetsLeft);
-    map.putInt("safeAreaInsetsRight", (Integer) constants.safeAreaInsetsRight);
+    if (getCurrentActivity() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      final Activity activity = getCurrentActivity();
+      final View view = activity.getWindow().getDecorView();
+      final WindowInsets insets = view.getRootWindowInsets();
+
+      map.putInt("safeAreaInsetsTop", insets.getSystemWindowInsetTop());
+      map.putInt("safeAreaInsetsBottom", insets.getSystemWindowInsetBottom());
+      map.putInt("safeAreaInsetsLeft", insets.getSystemWindowInsetLeft());
+      map.putInt("safeAreaInsetsRight", insets.getSystemWindowInsetRight());
+    } else {
+      map.putInt("safeAreaInsetsTop", 0);
+      map.putInt("safeAreaInsetsBottom", 0);
+      map.putInt("safeAreaInsetsLeft", 0);
+      map.putInt("safeAreaInsetsRight", 0);
+    }
 
     cb.invoke(map);
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ declare module "react-native-static-safe-area-insets" {
     public static safeAreaInsetsBottom: number;
     public static safeAreaInsetsLeft: number;
     public static safeAreaInsetsRight: number;
-    getSafeAreaInsets() : {
+    public static getSafeAreaInsets(): {
       top: number;
       bottom: number;
       left: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,10 +4,10 @@ declare module 'react-native-static-safe-area-insets' {
     public static safeAreaInsetsBottom: number;
     public static safeAreaInsetsLeft: number;
     public static safeAreaInsetsRight: number;
-    public static getSafeAreaInsetsTop(): number;
-    public static getSafeAreaInsetsBottom(): number;
-    public static getSafeAreaInsetsLeft(): number;
-    public static getSafeAreaInsetsRight(): number;
+    public static getSafeAreaInsetsTop(callback:(value:number) => void): void;
+    public static getSafeAreaInsetsBottom(callback:(value:number) => void): void;
+    public static getSafeAreaInsetsLeft(callback:(value:number) => void): void;
+    public static getSafeAreaInsetsRight(callback:(value:number) => void): void;
   }
 
   export default StaticSafeAreaInsets;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,10 +4,12 @@ declare module 'react-native-static-safe-area-insets' {
     public static safeAreaInsetsBottom: number;
     public static safeAreaInsetsLeft: number;
     public static safeAreaInsetsRight: number;
-    public static getSafeAreaInsetsTop(callback:(value:number) => void): void;
-    public static getSafeAreaInsetsBottom(callback:(value:number) => void): void;
-    public static getSafeAreaInsetsLeft(callback:(value:number) => void): void;
-    public static getSafeAreaInsetsRight(callback:(value:number) => void): void;
+    public static getSafeAreaInsets(callback:(insets:{
+      safeAreaInsetsTop: number;
+      safeAreaInsetsBottom: number;
+      safeAreaInsetsLeft: number;
+      safeAreaInsetsRight: number;
+    }) => void): void;
   }
 
   export default StaticSafeAreaInsets;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,12 @@ declare module "react-native-static-safe-area-insets" {
     public static safeAreaInsetsBottom: number;
     public static safeAreaInsetsLeft: number;
     public static safeAreaInsetsRight: number;
+    getSafeAreaInsets() : {
+      top: number;
+      bottom: number;
+      left: number;
+      right: number;
+    };
   }
 
   export default StaticSafeAreaInsets;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,13 @@
-declare module "react-native-static-safe-area-insets" {
+declare module 'react-native-static-safe-area-insets' {
   class StaticSafeAreaInsets {
     public static safeAreaInsetsTop: number;
     public static safeAreaInsetsBottom: number;
     public static safeAreaInsetsLeft: number;
     public static safeAreaInsetsRight: number;
-    public static getSafeAreaInsets(): {
-      top: number;
-      bottom: number;
-      left: number;
-      right: number;
-    };
+    public static getSafeAreaInsetsTop(): number;
+    public static getSafeAreaInsetsBottom(): number;
+    public static getSafeAreaInsetsLeft(): number;
+    public static getSafeAreaInsetsRight(): number;
   }
 
   export default StaticSafeAreaInsets;

--- a/ios/RNStaticSafeAreaInsets.m
+++ b/ios/RNStaticSafeAreaInsets.m
@@ -23,10 +23,10 @@ RCT_EXPORT_MODULE()
                  @"safeAreaInsetsBottom": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom),
                  @"safeAreaInsetsLeft": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.left),
                  @"safeAreaInsetsRight": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.right),
-                 @"getSafeAreaInsetsTop": @(self.getSafeAreaInsetsTop),
-                 @"getSafeAreaInsetsBottom": @(self.getSafeAreaInsetsBottom),
-                 @"getSafeAreaInsetsLeft": @(self.getSafeAreaInsetsLeft),
-                 @"getSafeAreaInsetsRight": @(self.getSafeAreaInsetsRight)
+                 @"getSafeAreaInsetsTop": self.getSafeAreaInsetsTop,
+                 @"getSafeAreaInsetsBottom": self.getSafeAreaInsetsBottom,
+                 @"getSafeAreaInsetsLeft": self.getSafeAreaInsetsLeft,
+                 @"getSafeAreaInsetsRight": self.getSafeAreaInsetsRight
                  };
     } else {
         return @{
@@ -34,15 +34,15 @@ RCT_EXPORT_MODULE()
                  @"safeAreaInsetsBottom": @(0),
                  @"safeAreaInsetsLeft": @(0),
                  @"safeAreaInsetsRight": @(0),
-                 @"getSafeAreaInsetsTop": @(self.getSafeAreaInsetsTop),
-                 @"getSafeAreaInsetsBottom": @(self.getSafeAreaInsetsBottom),
-                 @"getSafeAreaInsetsLeft": @(self.getSafeAreaInsetsLeft),
-                 @"getSafeAreaInsetsRight": @(self.getSafeAreaInsetsRight)
+                 @"getSafeAreaInsetsTop": self.getSafeAreaInsetsTop,
+                 @"getSafeAreaInsetsBottom": self.getSafeAreaInsetsBottom,
+                 @"getSafeAreaInsetsLeft": self.getSafeAreaInsetsLeft,
+                 @"getSafeAreaInsetsRight": self.getSafeAreaInsetsRight
                  };
     }
 }
 
-- (float) getSafeAreaInsetsTop
+- (NSNumber *) getSafeAreaInsetsTop
 {
     if (@available(iOS 11.0, *)) {
         return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.top);
@@ -51,7 +51,7 @@ RCT_EXPORT_MODULE()
     }
 }
 
-- (float) getSafeAreaInsetsBottom
+- (NSNumber *) getSafeAreaInsetsBottom
 {
     if (@available(iOS 11.0, *)) {
         return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom);
@@ -60,7 +60,7 @@ RCT_EXPORT_MODULE()
     }
 }
 
-- (float) getSafeAreaInsetsLeft
+- (NSNumber *) getSafeAreaInsetsLeft
 {
     if (@available(iOS 11.0, *)) {
         return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.left);
@@ -69,7 +69,7 @@ RCT_EXPORT_MODULE()
     }
 }
 
-- (float) getSafeAreaInsetsRight
+- (NSNumber *) getSafeAreaInsetsRight
 {
     if (@available(iOS 11.0, *)) {
         return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.right);

--- a/ios/RNStaticSafeAreaInsets.m
+++ b/ios/RNStaticSafeAreaInsets.m
@@ -17,29 +17,12 @@ RCT_EXPORT_MODULE()
 
 - (NSDictionary *)constantsToExport
 {
-    if (@available(iOS 11.0, *)) {
-        return @{
-                 @"safeAreaInsetsTop": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.top),
-                 @"safeAreaInsetsBottom": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom),
-                 @"safeAreaInsetsLeft": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.left),
-                 @"safeAreaInsetsRight": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.right),
-                 @"getSafeAreaInsetsTop": self.getSafeAreaInsetsTop,
-                 @"getSafeAreaInsetsBottom": self.getSafeAreaInsetsBottom,
-                 @"getSafeAreaInsetsLeft": self.getSafeAreaInsetsLeft,
-                 @"getSafeAreaInsetsRight": self.getSafeAreaInsetsRight
-                 };
-    } else {
-        return @{
-                 @"safeAreaInsetsTop": @(0),
-                 @"safeAreaInsetsBottom": @(0),
-                 @"safeAreaInsetsLeft": @(0),
-                 @"safeAreaInsetsRight": @(0),
-                 @"getSafeAreaInsetsTop": self.getSafeAreaInsetsTop,
-                 @"getSafeAreaInsetsBottom": self.getSafeAreaInsetsBottom,
-                 @"getSafeAreaInsetsLeft": self.getSafeAreaInsetsLeft,
-                 @"getSafeAreaInsetsRight": self.getSafeAreaInsetsRight
-                 };
-    }
+  return @{
+            @"safeAreaInsetsTop": self.getSafeAreaInsetsTop,
+            @"safeAreaInsetsBottom": self.getSafeAreaInsetsBottom,
+            @"safeAreaInsetsLeft": self.getSafeAreaInsetsLeft,
+            @"safeAreaInsetsRight": self.getSafeAreaInsetsRight
+            };
 }
 
 - (NSNumber *) getSafeAreaInsetsTop
@@ -76,6 +59,22 @@ RCT_EXPORT_MODULE()
     } else {
         return @(0);
     }
+}
+
+RCT_EXPORT_METHOD(getSafeAreaInsetsTop:(RCTResponseSenderBlock)callback){
+ callback(@[[NSNull null], self.getSafeAreaInsetsTop()]);
+}
+
+RCT_EXPORT_METHOD(getSafeAreaInsetsBottom:(RCTResponseSenderBlock)callback){
+ callback(@[[NSNull null], self.getSafeAreaInsetsBottom()]);
+}
+
+RCT_EXPORT_METHOD(getSafeAreaInsetsLeft:(RCTResponseSenderBlock)callback){
+ callback(@[[NSNull null], self.getSafeAreaInsetsLeft()]);
+}
+
+RCT_EXPORT_METHOD(getSafeAreaInsetsRight:(RCTResponseSenderBlock)callback){
+ callback(@[[NSNull null], self.getSafeAreaInsetsRight()]);
 }
 
 @end

--- a/ios/RNStaticSafeAreaInsets.m
+++ b/ios/RNStaticSafeAreaInsets.m
@@ -62,19 +62,19 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_METHOD(getSafeAreaInsetsTop:(RCTResponseSenderBlock)callback){
- callback(@[[NSNull null], self.getSafeAreaInsetsTop()]);
+ callback(@[[NSNull null], self.getSafeAreaInsetsTop]);
 }
 
 RCT_EXPORT_METHOD(getSafeAreaInsetsBottom:(RCTResponseSenderBlock)callback){
- callback(@[[NSNull null], self.getSafeAreaInsetsBottom()]);
+ callback(@[[NSNull null], self.getSafeAreaInsetsBottom]);
 }
 
 RCT_EXPORT_METHOD(getSafeAreaInsetsLeft:(RCTResponseSenderBlock)callback){
- callback(@[[NSNull null], self.getSafeAreaInsetsLeft()]);
+ callback(@[[NSNull null], self.getSafeAreaInsetsLeft]);
 }
 
 RCT_EXPORT_METHOD(getSafeAreaInsetsRight:(RCTResponseSenderBlock)callback){
- callback(@[[NSNull null], self.getSafeAreaInsetsRight()]);
+ callback(@[[NSNull null], self.getSafeAreaInsetsRight]);
 }
 
 @end

--- a/ios/RNStaticSafeAreaInsets.m
+++ b/ios/RNStaticSafeAreaInsets.m
@@ -34,4 +34,23 @@ RCT_EXPORT_MODULE()
     }
 }
 
+RCT_EXPORT_METHOD(getSafeAreaInsets:(RCTResponseSenderBlock)callback){
+    if (@available(iOS 11.0, *)) {
+        callback(@{
+                 @"top": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.top),
+                 @"bottom": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom),
+                 @"left": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.left),
+                 @"right": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.right)
+                 });
+    } else {
+      callback(@{
+                 @"top": @(0),
+                 @"bottom": @(0),
+                 @"left": @(0),
+                 @"right": @(0),
+                 });
+    }
+    
+}
+
 @end

--- a/ios/RNStaticSafeAreaInsets.m
+++ b/ios/RNStaticSafeAreaInsets.m
@@ -62,35 +62,19 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_METHOD(getSafeAreaInsetsTop:(RCTResponseSenderBlock)callback){
-    if (@available(iOS 11.0, *)) {
-        callback(@[@(UIApplication.sharedApplication.keyWindow.safeAreaInsets.top)]);
-    } else {
-        callback(@[@(0)]);
-    }
+    callback(@[self.getSafeAreaInsetsTop]);
 }
 
 RCT_EXPORT_METHOD(getSafeAreaInsetsBottom:(RCTResponseSenderBlock)callback){
-    if (@available(iOS 11.0, *)) {
-        callback(@[@(UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom)]);
-    } else {
-        callback(@[@(0)]);
-    }
+    callback(@[self.getSafeAreaInsetsBottom]);
 }
 
 RCT_EXPORT_METHOD(getSafeAreaInsetsLeft:(RCTResponseSenderBlock)callback){
-    if (@available(iOS 11.0, *)) {
-        callback(@[@(UIApplication.sharedApplication.keyWindow.safeAreaInsets.left)]);
-    } else {
-        callback(@[@(0)]);
-    }
+    callback(@[self.getSafeAreaInsetsLeft]);
 }
 
 RCT_EXPORT_METHOD(getSafeAreaInsetsRight:(RCTResponseSenderBlock)callback){
-    if (@available(iOS 11.0, *)) {
-        callback(@[@(UIApplication.sharedApplication.keyWindow.safeAreaInsets.right)]);
-    } else {
-        callback(@[@(0)]);
-    }
+    callback(@[self.getSafeAreaInsetsRight]);
 }
 
 @end

--- a/ios/RNStaticSafeAreaInsets.m
+++ b/ios/RNStaticSafeAreaInsets.m
@@ -17,64 +17,30 @@ RCT_EXPORT_MODULE()
 
 - (NSDictionary *)constantsToExport
 {
-  return @{
-            @"safeAreaInsetsTop": self.getSafeAreaInsetsTop,
-            @"safeAreaInsetsBottom": self.getSafeAreaInsetsBottom,
-            @"safeAreaInsetsLeft": self.getSafeAreaInsetsLeft,
-            @"safeAreaInsetsRight": self.getSafeAreaInsetsRight
-            };
+  return self.getSafeAreaInsets;
 }
 
-- (NSNumber *) getSafeAreaInsetsTop
+- (NSDictionary *) getSafeAreaInsets
 {
     if (@available(iOS 11.0, *)) {
-        return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.top);
+        return @{
+                 @"safeAreaInsetsTop": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.top),
+                 @"safeAreaInsetsBottom": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom),
+                 @"safeAreaInsetsLeft": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.left),
+                 @"safeAreaInsetsRight": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.right)
+                 };
     } else {
-        return @(0);
+        return @{
+                 @"safeAreaInsetsTop": @(0),
+                 @"safeAreaInsetsBottom": @(0),
+                 @"safeAreaInsetsLeft": @(0),
+                 @"safeAreaInsetsRight": @(0),
+                 };
     }
 }
 
-- (NSNumber *) getSafeAreaInsetsBottom
-{
-    if (@available(iOS 11.0, *)) {
-        return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom);
-    } else {
-        return @(0);
-    }
-}
-
-- (NSNumber *) getSafeAreaInsetsLeft
-{
-    if (@available(iOS 11.0, *)) {
-        return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.left);
-    } else {
-        return @(0);
-    }
-}
-
-- (NSNumber *) getSafeAreaInsetsRight
-{
-    if (@available(iOS 11.0, *)) {
-        return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.right);
-    } else {
-        return @(0);
-    }
-}
-
-RCT_EXPORT_METHOD(getSafeAreaInsetsTop:(RCTResponseSenderBlock)callback){
-    callback(@[self.getSafeAreaInsetsTop]);
-}
-
-RCT_EXPORT_METHOD(getSafeAreaInsetsBottom:(RCTResponseSenderBlock)callback){
-    callback(@[self.getSafeAreaInsetsBottom]);
-}
-
-RCT_EXPORT_METHOD(getSafeAreaInsetsLeft:(RCTResponseSenderBlock)callback){
-    callback(@[self.getSafeAreaInsetsLeft]);
-}
-
-RCT_EXPORT_METHOD(getSafeAreaInsetsRight:(RCTResponseSenderBlock)callback){
-    callback(@[self.getSafeAreaInsetsRight]);
+RCT_EXPORT_METHOD(getSafeAreaInsets:(RCTResponseSenderBlock)callback){
+    callback(@[self.getSafeAreaInsets]);
 }
 
 @end

--- a/ios/RNStaticSafeAreaInsets.m
+++ b/ios/RNStaticSafeAreaInsets.m
@@ -42,37 +42,37 @@ RCT_EXPORT_MODULE()
     }
 }
 
-- (NSNumber*) getSafeAreaInsetsTop
+- (float) getSafeAreaInsetsTop
 {
     if (@available(iOS 11.0, *)) {
-        return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.top)
+        return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.top);
     } else {
         return @(0);
     }
 }
 
-- (NSNumber*) getSafeAreaInsetsBottom
+- (float) getSafeAreaInsetsBottom
 {
     if (@available(iOS 11.0, *)) {
-        return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom)
+        return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom);
     } else {
         return @(0);
     }
 }
 
-- (NSNumber*) getSafeAreaInsetsLeft
+- (float) getSafeAreaInsetsLeft
 {
     if (@available(iOS 11.0, *)) {
-        return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.left)
+        return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.left);
     } else {
         return @(0);
     }
 }
 
-- (NSNumber*) getSafeAreaInsetsRight
+- (float) getSafeAreaInsetsRight
 {
     if (@available(iOS 11.0, *)) {
-        return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.right)
+        return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.right);
     } else {
         return @(0);
     }

--- a/ios/RNStaticSafeAreaInsets.m
+++ b/ios/RNStaticSafeAreaInsets.m
@@ -62,19 +62,35 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_METHOD(getSafeAreaInsetsTop:(RCTResponseSenderBlock)callback){
- callback(@[[NSNull null], self.getSafeAreaInsetsTop]);
+    if (@available(iOS 11.0, *)) {
+        callback(@[[NSNull null], @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.top)]);
+    } else {
+        callback(@[[NSNull null], @(0)]);
+    }
 }
 
 RCT_EXPORT_METHOD(getSafeAreaInsetsBottom:(RCTResponseSenderBlock)callback){
- callback(@[[NSNull null], self.getSafeAreaInsetsBottom]);
+    if (@available(iOS 11.0, *)) {
+        callback(@[[NSNull null], @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom)]);
+    } else {
+        callback(@[[NSNull null], @(0)]);
+    }
 }
 
 RCT_EXPORT_METHOD(getSafeAreaInsetsLeft:(RCTResponseSenderBlock)callback){
- callback(@[[NSNull null], self.getSafeAreaInsetsLeft]);
+    if (@available(iOS 11.0, *)) {
+        callback(@[[NSNull null], @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.left)]);
+    } else {
+        callback(@[[NSNull null], @(0)]);
+    }
 }
 
 RCT_EXPORT_METHOD(getSafeAreaInsetsRight:(RCTResponseSenderBlock)callback){
- callback(@[[NSNull null], self.getSafeAreaInsetsRight]);
+    if (@available(iOS 11.0, *)) {
+        callback(@[[NSNull null], @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.right)]);
+    } else {
+        callback(@[[NSNull null], @(0)]);
+    }
 }
 
 @end

--- a/ios/RNStaticSafeAreaInsets.m
+++ b/ios/RNStaticSafeAreaInsets.m
@@ -63,33 +63,33 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(getSafeAreaInsetsTop:(RCTResponseSenderBlock)callback){
     if (@available(iOS 11.0, *)) {
-        callback(@[[NSNull null], @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.top)]);
+        callback(@[@(UIApplication.sharedApplication.keyWindow.safeAreaInsets.top)]);
     } else {
-        callback(@[[NSNull null], @(0)]);
+        callback(@[@(0)]);
     }
 }
 
 RCT_EXPORT_METHOD(getSafeAreaInsetsBottom:(RCTResponseSenderBlock)callback){
     if (@available(iOS 11.0, *)) {
-        callback(@[[NSNull null], @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom)]);
+        callback(@[@(UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom)]);
     } else {
-        callback(@[[NSNull null], @(0)]);
+        callback(@[@(0)]);
     }
 }
 
 RCT_EXPORT_METHOD(getSafeAreaInsetsLeft:(RCTResponseSenderBlock)callback){
     if (@available(iOS 11.0, *)) {
-        callback(@[[NSNull null], @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.left)]);
+        callback(@[@(UIApplication.sharedApplication.keyWindow.safeAreaInsets.left)]);
     } else {
-        callback(@[[NSNull null], @(0)]);
+        callback(@[@(0)]);
     }
 }
 
 RCT_EXPORT_METHOD(getSafeAreaInsetsRight:(RCTResponseSenderBlock)callback){
     if (@available(iOS 11.0, *)) {
-        callback(@[[NSNull null], @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.right)]);
+        callback(@[@(UIApplication.sharedApplication.keyWindow.safeAreaInsets.right)]);
     } else {
-        callback(@[[NSNull null], @(0)]);
+        callback(@[@(0)]);
     }
 }
 

--- a/ios/RNStaticSafeAreaInsets.m
+++ b/ios/RNStaticSafeAreaInsets.m
@@ -22,7 +22,11 @@ RCT_EXPORT_MODULE()
                  @"safeAreaInsetsTop": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.top),
                  @"safeAreaInsetsBottom": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom),
                  @"safeAreaInsetsLeft": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.left),
-                 @"safeAreaInsetsRight": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.right)
+                 @"safeAreaInsetsRight": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.right),
+                 @"getSafeAreaInsetsTop": @(self.getSafeAreaInsetsTop),
+                 @"getSafeAreaInsetsBottom": @(self.getSafeAreaInsetsBottom),
+                 @"getSafeAreaInsetsLeft": @(self.getSafeAreaInsetsLeft),
+                 @"getSafeAreaInsetsRight": @(self.getSafeAreaInsetsRight)
                  };
     } else {
         return @{
@@ -30,27 +34,48 @@ RCT_EXPORT_MODULE()
                  @"safeAreaInsetsBottom": @(0),
                  @"safeAreaInsetsLeft": @(0),
                  @"safeAreaInsetsRight": @(0),
+                 @"getSafeAreaInsetsTop": @(self.getSafeAreaInsetsTop),
+                 @"getSafeAreaInsetsBottom": @(self.getSafeAreaInsetsBottom),
+                 @"getSafeAreaInsetsLeft": @(self.getSafeAreaInsetsLeft),
+                 @"getSafeAreaInsetsRight": @(self.getSafeAreaInsetsRight)
                  };
     }
 }
 
-RCT_EXPORT_METHOD(getSafeAreaInsets:(RCTResponseSenderBlock)callback){
+- (NSNumber*) getSafeAreaInsetsTop
+{
     if (@available(iOS 11.0, *)) {
-        callback(@{
-                 @"top": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.top),
-                 @"bottom": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom),
-                 @"left": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.left),
-                 @"right": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.right)
-                 });
+        return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.top)
     } else {
-      callback(@{
-                 @"top": @(0),
-                 @"bottom": @(0),
-                 @"left": @(0),
-                 @"right": @(0),
-                 });
+        return @(0);
     }
-    
+}
+
+- (NSNumber*) getSafeAreaInsetsBottom
+{
+    if (@available(iOS 11.0, *)) {
+        return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom)
+    } else {
+        return @(0);
+    }
+}
+
+- (NSNumber*) getSafeAreaInsetsLeft
+{
+    if (@available(iOS 11.0, *)) {
+        return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.left)
+    } else {
+        return @(0);
+    }
+}
+
+- (NSNumber*) getSafeAreaInsetsRight
+{
+    if (@available(iOS 11.0, *)) {
+        return @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.right)
+    } else {
+        return @(0);
+    }
 }
 
 @end


### PR DESCRIPTION
This is an attempt to fix #10

With the `getSafeAreaInsets(callback)` method, a `useSafeAreaInsets` hook could be created to ensure fresh inset values are used in components, therefore supporting orientation change:

```javascript
import React from 'react';
import { Dimensions } from 'react-native';
import StaticSafeAreaInsets from 'react-native-static-safe-area-insets';

function useSafeAreaInsets() {
  const [insets, setInsets] = React.useState({
    safeAreaInsetsTop: StaticSafeAreaInsets.safeAreaInsetsTop,
    safeAreaInsetsBottom: StaticSafeAreaInsets.safeAreaInsetsBottom,
    safeAreaInsetsLeft: StaticSafeAreaInsets.safeAreaInsetsLeft,
    safeAreaInsetsRight: StaticSafeAreaInsets.safeAreaInsetsRight,
  });

   React.useEffect(() => {
    let didCancel = false;

     function handleDimensionsChange() {
      StaticSafeAreaInsets.getSafeAreaInsets(values => {
        if (didCancel) {
          return;
        }
        setInsets(values);
      });
    }

     handleDimensionsChange();

     Dimensions.addEventListener('change', handleDimensionsChange);

     return () => {
      didCancel = true;
      Dimensions.removeEventListener('change', handleDimensionsChange);
    };
  }, []);

  return insets;
}
```

I'm open for feedback as I don't have much experience on the native side.