### PR TITLE
fix(Android): Return dp instead of px 

### DIFF
--- a/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
+++ b/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.PixelUtil;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -42,10 +43,10 @@ public class RNStaticSafeAreaInsetsModule extends ReactContextBaseJavaModule {
       final View view = activity.getWindow().getDecorView();
       final WindowInsets insets = view.getRootWindowInsets();
 
-      constants.put("safeAreaInsetsTop", insets.getSystemWindowInsetTop());
-      constants.put("safeAreaInsetsBottom", insets.getSystemWindowInsetBottom());
-      constants.put("safeAreaInsetsLeft", insets.getSystemWindowInsetLeft());
-      constants.put("safeAreaInsetsRight", insets.getSystemWindowInsetRight());
+      constants.put("safeAreaInsetsTop", PixelUtil.toDIPFromPixel(insets.getSystemWindowInsetTop()));
+      constants.put("safeAreaInsetsBottom", PixelUtil.toDIPFromPixel(insets.getSystemWindowInsetBottom()));
+      constants.put("safeAreaInsetsLeft", PixelUtil.toDIPFromPixel(insets.getSystemWindowInsetLeft()));
+      constants.put("safeAreaInsetsRight", PixelUtil.toDIPFromPixel(insets.getSystemWindowInsetRight()));
     } else {
       constants.put("safeAreaInsetsTop", 0);
       constants.put("safeAreaInsetsBottom", 0);


### PR DESCRIPTION
## Summary

React Native uses density-independent pixels, or **dp**, as it's default unit. This will size elements so that they are roughly the same physical size on different devices. However, on Android we are returning pixels (px) instead of dp, resulting in a non-consistent look on different devices.

## Screenshots
I am using on the navigation header.
Without fix:
![photo5827966279745647091](https://user-images.githubusercontent.com/44206249/72292046-f0980680-3650-11ea-887b-e1b54f0f8288.jpg)

With fix:
![photo5827966279745647092](https://user-images.githubusercontent.com/44206249/72292051-f1c93380-3650-11ea-8c92-3785b62dddd3.jpg)