### PR TITLE
Use float zeroes (instead of int) on Android, for the fallback case.

### DIFF
--- a/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
+++ b/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
@@ -48,10 +48,10 @@ public class RNStaticSafeAreaInsetsModule extends ReactContextBaseJavaModule {
       constants.put("safeAreaInsetsLeft", PixelUtil.toDIPFromPixel(insets.getSystemWindowInsetLeft()));
       constants.put("safeAreaInsetsRight", PixelUtil.toDIPFromPixel(insets.getSystemWindowInsetRight()));
     } else {
-      constants.put("safeAreaInsetsTop", 0);
-      constants.put("safeAreaInsetsBottom", 0);
-      constants.put("safeAreaInsetsLeft", 0);
-      constants.put("safeAreaInsetsRight", 0);
+      constants.put("safeAreaInsetsTop", 0f);
+      constants.put("safeAreaInsetsBottom", 0f);
+      constants.put("safeAreaInsetsLeft", 0f);
+      constants.put("safeAreaInsetsRight", 0f);
     }
 
     return constants;


### PR DESCRIPTION
On versions of Android that don't support window insets, the fallback case inserts integer zeroes into the `constants` map. Which causes a cast error in `getSafeAreaInsets` trying to cast int to float.

![image](https://user-images.githubusercontent.com/112166/123083761-b07dab80-d420-11eb-8981-1d156b50aa92.png)
