### PR TITLE
feat: android insets logic improved for api 30+

### DIFF
--- a/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
+++ b/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
@@ -13,8 +13,10 @@ import java.util.HashMap;
 
 import android.view.WindowInsets;
 import android.view.View;
+import android.view.WindowInsetsController;
 import android.os.Build;
 import android.app.Activity;
+import android.graphics.Insets;
 
 public class RNStaticSafeAreaInsetsModule extends ReactContextBaseJavaModule {
 
@@ -43,10 +45,31 @@ public class RNStaticSafeAreaInsetsModule extends ReactContextBaseJavaModule {
       final View view = activity.getWindow().getDecorView();
       final WindowInsets insets = view.getRootWindowInsets();
 
-      constants.put("safeAreaInsetsTop", PixelUtil.toDIPFromPixel(insets.getSystemWindowInsetTop()));
-      constants.put("safeAreaInsetsBottom", PixelUtil.toDIPFromPixel(insets.getSystemWindowInsetBottom()));
-      constants.put("safeAreaInsetsLeft", PixelUtil.toDIPFromPixel(insets.getSystemWindowInsetLeft()));
-      constants.put("safeAreaInsetsRight", PixelUtil.toDIPFromPixel(insets.getSystemWindowInsetRight()));
+      final Boolean isFullscreen = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R ?
+        view.getWindowInsetsController().getSystemBarsBehavior() == WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        :
+        view.getWindowSystemUiVisibility() == View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+
+      if (isFullscreen) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+          final Insets insets30 = insets.getInsets(WindowInsets.Type.systemGestures());
+
+          constants.put("safeAreaInsetsTop", insets30.top);
+          constants.put("safeAreaInsetsBottom", insets30.bottom);
+          constants.put("safeAreaInsetsLeft", insets30.left);
+          constants.put("safeAreaInsetsRight", insets30.right);
+        } else {
+          constants.put("safeAreaInsetsTop", PixelUtil.toDIPFromPixel(insets.getSystemWindowInsetTop()));
+          constants.put("safeAreaInsetsBottom", PixelUtil.toDIPFromPixel(insets.getSystemWindowInsetBottom()));
+          constants.put("safeAreaInsetsLeft", PixelUtil.toDIPFromPixel(insets.getSystemWindowInsetLeft()));
+          constants.put("safeAreaInsetsRight", PixelUtil.toDIPFromPixel(insets.getSystemWindowInsetRight()));
+        }
+      } else {
+        constants.put("safeAreaInsetsTop", 0f);
+        constants.put("safeAreaInsetsBottom", 0f);
+        constants.put("safeAreaInsetsLeft", 0f);
+        constants.put("safeAreaInsetsRight", 0f);
+      }
     } else {
       constants.put("safeAreaInsetsTop", 0f);
       constants.put("safeAreaInsetsBottom", 0f);


### PR DESCRIPTION
<!--
    Use this template for changes related to the **React Native Static Safe Area Insets**.
    All team members will be notified as reviewers 👀
-->

### Purpose of this MR 🎯

What kind of change does this Merge Request introduce?

<!-- Check one of the following options with "x". -->

-   [x] Feature
-   [x] Bug fix
-   [ ] Tests only
-   [ ] Refactoring (no functional changes, no API changes)
-   [ ] Build/CI related changes
-   [ ] Documentation content changes
-   [ ] Code style update (formatting, local variables)
-   [ ] Other. Please describe:

### Changes 📝

<!-- Describe the changes introduced by this MR. -->
#### Android

* Logic updated for API 30+ using [getInsets](https://developer.android.com/reference/android/view/WindowInsets#getInsets(int)) instead of the deprecated [getSystemWindowInset*](https://developer.android.com/reference/android/view/WindowInsets#getSystemWindowInsetTop())
* Introduced a condition that only returns insets if the app is in fullscreen/immersive mode

### Does this MR introduce a breaking change? ⚠️

-   [ ] No
-   [x] Yes
<!-- ::WARNING:: If your MR has a breaking change, your commit body message MUST include "BREAKING CHANGE" -->

<!-- If this MR contains a breaking change, please describe the impact. -->

If an app is **not** in fullscreen/immersive mode the returned insets values will always be zero.

### Related issue 📎

https://github.com/Gaspard-Bruno/react-native-static-safe-area-insets/issues/18

### Reviewers 👀

@CarlosUvaSilva

<!-- Automatically tag the MR with labels -->

<!-- Add additional relevant labels either here using /label or in the GitHub UI below -->