### PR TITLE
feat: fallback for when insets are null

### DIFF
--- a/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
+++ b/android/src/main/java/com/gaspardbruno/staticsafeareainsets/RNStaticSafeAreaInsetsModule.java
@@ -45,19 +45,16 @@ public class RNStaticSafeAreaInsetsModule extends ReactContextBaseJavaModule {
       final View view = activity.getWindow().getDecorView();
       final WindowInsets insets = view.getRootWindowInsets();
 
-      final Boolean isFullscreen = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R ?
-        view.getWindowInsetsController().getSystemBarsBehavior() == WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        :
-        view.getWindowSystemUiVisibility() == View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+      final Boolean isFullscreen = (view.getSystemUiVisibility() & View.SYSTEM_UI_FLAG_IMMERSIVE) == View.SYSTEM_UI_FLAG_IMMERSIVE;
 
-      if (isFullscreen) {
+      if (insets != null && isFullscreen) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
           final Insets insets30 = insets.getInsets(WindowInsets.Type.systemGestures());
 
-          constants.put("safeAreaInsetsTop", insets30.top);
-          constants.put("safeAreaInsetsBottom", insets30.bottom);
-          constants.put("safeAreaInsetsLeft", insets30.left);
-          constants.put("safeAreaInsetsRight", insets30.right);
+          constants.put("safeAreaInsetsTop", (float) insets30.top);
+          constants.put("safeAreaInsetsBottom", (float) insets30.bottom);
+          constants.put("safeAreaInsetsLeft", (float) insets30.left);
+          constants.put("safeAreaInsetsRight", (float) insets30.right);
         } else {
           constants.put("safeAreaInsetsTop", PixelUtil.toDIPFromPixel(insets.getSystemWindowInsetTop()));
           constants.put("safeAreaInsetsBottom", PixelUtil.toDIPFromPixel(insets.getSystemWindowInsetBottom()));


### PR DESCRIPTION
<!--
    Use this template for changes related to the **React Native Static Safe Area Insets**.
    All team members will be notified as reviewers 👀
-->

### Purpose of this MR 🎯

What kind of change does this Merge Request introduce?

<!-- Check one of the following options with "x". -->

-   [x] Feature
-   [ ] Bug fix
-   [ ] Tests only
-   [ ] Refactoring (no functional changes, no API changes)
-   [ ] Build/CI related changes
-   [ ] Documentation content changes
-   [ ] Code style update (formatting, local variables)
-   [ ] Other. Please describe:

### Changes 📝

A fallback for cases where the Android window insets are temporally null.
<!-- Describe the changes introduced by this MR. -->

### Does this MR introduce a breaking change? ⚠️

-   [x] No
-   [ ] Yes
<!-- ::WARNING:: If your MR has a breaking change, your commit body message MUST include "BREAKING CHANGE" -->

<!-- If this MR contains a breaking change, please describe the impact. -->

### Related issue 📎

<!-- If this MR refers to a Github issue please uncomment one of the lines below and insert the issue number -->
Github [issue-20](https://github.com/Gaspard-Bruno/react-native-static-safe-area-insets/issues/20)

### Reviewers 👀

@CarlosUvaSilva

<!-- Automatically tag the MR with labels -->

<!-- Add additional relevant labels either here using /label or in the GitHub UI below -->