### PR TITLE
feat: Add support for RN 0.72

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,7 @@ def DEFAULT_MIN_SDK_VERSION = 16
 def DEFAULT_TARGET_SDK_VERSION = 28
 
 android {
+  namespace 'com.gaspardbruno.staticsafeareainsets'
   compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
   buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
 


### PR DESCRIPTION
Adds `namespace` to `build.gradle` (this is required by Gradle 8, which RN 0.72 uses)
