### PR TITLE
fix: inset=0 when open app from notify

### DIFF
--- a/ios/RNStaticSafeAreaInsets.m
+++ b/ios/RNStaticSafeAreaInsets.m
@@ -23,11 +23,13 @@ RCT_EXPORT_MODULE()
 - (NSDictionary *) getSafeAreaInsets
 {
     if (@available(iOS 11.0, *)) {
+        UIWindow *window = UIApplication.sharedApplication.windows.firstObject;
+        
         return @{
-            @"safeAreaInsetsTop": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.top),
-            @"safeAreaInsetsBottom": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom),
-            @"safeAreaInsetsLeft": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.left),
-            @"safeAreaInsetsRight": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.right)
+            @"safeAreaInsetsTop": @(window.safeAreaInsets.top),
+            @"safeAreaInsetsBottom": @(window.safeAreaInsets.bottom),
+            @"safeAreaInsetsLeft": @(window.safeAreaInsets.left),
+            @"safeAreaInsetsRight": @(window.safeAreaInsets.right)
         };
     } else {
         return @{

--- a/ios/RNStaticSafeAreaInsets.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/RNStaticSafeAreaInsets.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-static-safe-area-insets",
+  "name": "@nnpmai/react-native-static-safe-area-insets",
   "title": "React Native Static Safe Area Insets",
   "version": "2.2.0",
   "description": "React Native package that exposed the Safe Area insets as constants",
@@ -16,8 +16,8 @@
     "react-native"
   ],
   "author": {
-    "name": "Gaspard+Bruno",
-    "email": "hello@gaspardbruno.com"
+    "name": "nnpmai",
+    "email": "npmai.huflit@gmail.com"
   },
   "types": "index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
<!--
    Use this template for changes related to the **React Native Static Safe Area Insets**.
    All team members will be notified as reviewers 👀
-->

### Purpose of this MR 🎯

What kind of change does this Merge Request introduce?

<!-- Check one of the following options with "x". -->

-   [ ] Feature
-   [x] Bug fix
-   [ ] Tests only
-   [ ] Refactoring (no functional changes, no API changes)
-   [ ] Build/CI related changes
-   [ ] Documentation content changes
-   [ ] Code style update (formatting, local variables)
-   [ ] Other. Please describe:

### Changes 📝

<!-- Describe the changes introduced by this MR. -->

### Screenshots 🖼

<!-- Please add screenshots or videos that illustrate any new or updated UIs. -->

### Does this MR introduce a breaking change? ⚠️

-   [ ] No
-   [ ] Yes
<!-- ::WARNING:: If your MR has a breaking change, your commit body message MUST include "BREAKING CHANGE" -->

<!-- If this MR contains a breaking change, please describe the impact. -->

### Related issue 📎

<!-- If this MR refers to a Github issue please uncomment one of the lines below and insert the issue number -->
<!-- Github [issue-XXX](https://github.com/Gaspard-Bruno/react-native-static-safe-area-insets/issues/XXX)-->

### Reviewers 👀

@jpamarohorta
@CarlosUvaSilva

<!-- Automatically tag the MR with labels -->

<!-- Add additional relevant labels either here using /label or in the GitHub UI below -->