### PR TITLE
fix: Update safe area insets 

### DIFF
--- a/ios/RNStaticSafeAreaInsets.m
+++ b/ios/RNStaticSafeAreaInsets.m
@@ -23,11 +23,13 @@ RCT_EXPORT_MODULE()
 - (NSDictionary *) getSafeAreaInsets
 {
     if (@available(iOS 11.0, *)) {
+        UIWindow *window = UIApplication.sharedApplication.windows.firstObject;
+        
         return @{
-            @"safeAreaInsetsTop": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.top),
-            @"safeAreaInsetsBottom": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom),
-            @"safeAreaInsetsLeft": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.left),
-            @"safeAreaInsetsRight": @(UIApplication.sharedApplication.keyWindow.safeAreaInsets.right)
+            @"safeAreaInsetsTop": @(window.safeAreaInsets.top),
+            @"safeAreaInsetsBottom": @(window.safeAreaInsets.bottom),
+            @"safeAreaInsetsLeft": @(window.safeAreaInsets.left),
+            @"safeAreaInsetsRight": @(window.safeAreaInsets.right)
         };
     } else {
         return @{


### PR DESCRIPTION
Update safe area insets retrieval to use the main window instead of keyWindow

<!--
    Use this template for changes related to the **React Native Static Safe Area Insets**.
    All team members will be notified as reviewers 👀
-->

### Purpose of this MR 🎯

What kind of change does this Merge Request introduce?

<!-- Check one of the following options with "x". -->

-   [ ] Feature
-   [x] Bug fix
-   [ ] Tests only
-   [ ] Refactoring (no functional changes, no API changes)
-   [ ] Build/CI related changes
-   [ ] Documentation content changes
-   [ ] Code style update (formatting, local variables)
-   [ ] Other. Please describe:

### Changes 📝

<!-- Describe the changes introduced by this MR. -->

### Screenshots 🖼

<!-- Please add screenshots or videos that illustrate any new or updated UIs. -->

### Does this MR introduce a breaking change? ⚠️

-   [ ] No
-   [ ] Yes
<!-- ::WARNING:: If your MR has a breaking change, your commit body message MUST include "BREAKING CHANGE" -->

<!-- If this MR contains a breaking change, please describe the impact. -->

### Related issue 📎

<!-- If this MR refers to a Github issue please uncomment one of the lines below and insert the issue number -->
<!-- Github [issue-XXX](https://github.com/Gaspard-Bruno/react-native-static-safe-area-insets/issues/XXX)-->

### Reviewers 👀

@jpamarohorta
@CarlosUvaSilva

<!-- Automatically tag the MR with labels -->

<!-- Add additional relevant labels either here using /label or in the GitHub UI below -->